### PR TITLE
Change event handler from ConnectivityChanged to ConnectivityTypeChan…

### DIFF
--- a/Exercise 1/Completed/NetStatus/NetworkViewPage.xaml.cs
+++ b/Exercise 1/Completed/NetStatus/NetworkViewPage.xaml.cs
@@ -23,17 +23,17 @@ namespace NetStatus
 			ConnectionDetails.Text = CrossConnectivity.Current
                 .ConnectionTypes.First ().ToString ();
 
-			CrossConnectivity.Current.ConnectivityChanged += UpdateNetworkInfo;
+			CrossConnectivity.Current.ConnectivityTypeChanged += UpdateNetworkInfo;
 		}
 
 		protected override void OnDisappearing ()
 		{
 			base.OnDisappearing ();
 
-			CrossConnectivity.Current.ConnectivityChanged -= UpdateNetworkInfo;
+			CrossConnectivity.Current.ConnectivityTypeChanged -= UpdateNetworkInfo;
 		}
 
-		private void UpdateNetworkInfo (object sender, ConnectivityChangedEventArgs e)
+		private void UpdateNetworkInfo (object sender, ConnectivityTypeChangedEventArgs e)
 		{
 			if (CrossConnectivity.Current != null && CrossConnectivity.Current.ConnectionTypes != null) {
 				var connectionType = CrossConnectivity.Current.ConnectionTypes.FirstOrDefault ();


### PR DESCRIPTION
…ged.

The objective of this part of the exercise on https://elearning.xamarin.com/forms/xam150/1-obtain-the-devices-network-capabilities/exercise1/9-display-type (step 4-7) was to detect a change in network type (e.g. change from WiFi to Cellular). In order to detect this change we need to subscribe to the ConnectivityTypeChanged event and not to the ConnectivityChanged event again.

Of course the description on the page (see link above) also needs to be updated.

<!--
Thank you so much for your contribution. Before you submit a pull request, please read the following:

1. Ensure you have read over contribution guidelines in the README - https://github.com/XamarinUniversity/XAM150/blob/master/README.md.

2. Delete everything in this comment block.
-->
